### PR TITLE
Fix shouldExportBeDeleted call

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,10 +35,9 @@ module.exports = (mode) => {
                 if (
                   shouldExportBeDeleted(
                     mode,
-                    t.isIdentifier(s.node.exported)
+                    s.isIdentifier(s.node.exported)
                       ? s.node.exported.name
-                      : s.node.exported.value,
-                    exportNamedState
+                      : s.node.exported.value
                   )
                 ) {
                   s.remove();


### PR DESCRIPTION
`exportNamedState` wasn't a variable and `t` was used but not a variable anywhere.

Fixes https://github.com/erzr/next-babel-conditional-ssg-ssr/issues/3 and works with nextjs 12.